### PR TITLE
Performance improvement of about 200%

### DIFF
--- a/include/ww898/cp_utf32.hpp
+++ b/include/ww898/cp_utf32.hpp
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <stdexcept>
+#include <ww898/utf_config.hpp>
 
 namespace ww898 {
 namespace utf {
@@ -46,19 +47,19 @@ struct utf32 final
     }
 
     template<typename ReadFn>
-    static uint32_t read(ReadFn && read_fn)
+    FORCE_INLINE static uint32_t read(ReadFn && read_fn)
     {
-        char_type const ch = std::forward<ReadFn>(read_fn)();
+        char_type const ch = std::forward<ReadFn>(read_fn).read1();
         if (ch < 0x80000000)
             return ch;
         throw std::runtime_error("Too large utf32 char");
     }
 
     template<typename WriteFn>
-    static void write(uint32_t const cp, WriteFn && write_fn)
+    FORCE_INLINE static void write(uint32_t const cp, WriteFn && write_fn)
     {
         if (cp < 0x80000000)
-            std::forward<WriteFn>(write_fn)(static_cast<char_type>(cp));
+            std::forward<WriteFn>(write_fn).write1(static_cast<char_type>(cp));
         else
             throw std::runtime_error("Too large utf32 code point");
     }

--- a/include/ww898/cp_utf8.hpp
+++ b/include/ww898/cp_utf8.hpp
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <stdexcept>
+#include <ww898/utf_config.hpp>
 
 namespace ww898 {
 namespace utf {
@@ -68,91 +69,114 @@ struct utf8 final
     }
 
     template<typename ReadFn>
-    static uint32_t read(ReadFn && read_fn)
+    FORCE_INLINE static uint32_t read(ReadFn && read_fn)
     {
-        char_type const ch0 = read_fn();
+        char_type const ch0 = read_fn.read1();
         if (ch0 < 0x80) // 0xxx_xxxx
             return ch0;
         if (ch0 < 0xC0)
             throw std::runtime_error("The utf8 first char in sequence is incorrect");
         if (ch0 < 0xE0) // 110x_xxxx 10xx_xxxx
         {
-            char_type const ch1 = read_fn(); if (ch1 >> 6 != 2) goto _err;
+            char_type const ch1 = read_fn.read1(); 
+            if (ch1 >> 6 != 2) goto _err;
             return (ch0 << 6) + ch1 - 0x3080;
         }
         if (ch0 < 0xF0) // 1110_xxxx 10xx_xxxx 10xx_xxxx
         {
-            char_type const ch1 = read_fn(); if (ch1 >> 6 != 2) goto _err;
-            char_type const ch2 = read_fn(); if (ch2 >> 6 != 2) goto _err;
+            auto [ch1, ch2] = read_fn.read2();
+            if (ch1 >> 6 != 2) goto _err;
+            if (ch2 >> 6 != 2) goto _err;
             return (ch0 << 12) + (ch1 << 6) + ch2 - 0xE2080;
         }
         if (ch0 < 0xF8) // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
         {
-            char_type const ch1 = read_fn(); if (ch1 >> 6 != 2) goto _err;
-            char_type const ch2 = read_fn(); if (ch2 >> 6 != 2) goto _err;
-            char_type const ch3 = read_fn(); if (ch3 >> 6 != 2) goto _err;
+            auto [ch1, ch2, ch3] = read_fn.read3();
+            if (ch1 >> 6 != 2) goto _err;
+            if (ch2 >> 6 != 2) goto _err;
+            if (ch3 >> 6 != 2) goto _err;
             return (ch0 << 18) + (ch1 << 12) + (ch2 << 6) + ch3 - 0x3C82080;
         }
         if (ch0 < 0xFC) // 1111_10xx 10xx_xxxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
         {
-            char_type const ch1 = read_fn(); if (ch1 >> 6 != 2) goto _err;
-            char_type const ch2 = read_fn(); if (ch2 >> 6 != 2) goto _err;
-            char_type const ch3 = read_fn(); if (ch3 >> 6 != 2) goto _err;
-            char_type const ch4 = read_fn(); if (ch4 >> 6 != 2) goto _err;
+            auto [ch1, ch2, ch3, ch4] = read_fn.read4();
+            if (ch1 >> 6 != 2) goto _err;
+            if (ch2 >> 6 != 2) goto _err;
+            if (ch3 >> 6 != 2) goto _err;
+            if (ch4 >> 6 != 2) goto _err;
             return (ch0 << 24) + (ch1 << 18) + (ch2 << 12) + (ch3 << 6) + ch4 - 0xFA082080;
         }
         if (ch0 < 0xFE) // 1111_110x 10xx_xxxx 10xx_xxxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
         {
-            char_type const ch1 = read_fn(); if (ch1 >> 6 != 2) goto _err;
-            char_type const ch2 = read_fn(); if (ch2 >> 6 != 2) goto _err;
-            char_type const ch3 = read_fn(); if (ch3 >> 6 != 2) goto _err;
-            char_type const ch4 = read_fn(); if (ch4 >> 6 != 2) goto _err;
-            char_type const ch5 = read_fn(); if (ch5 >> 6 != 2) goto _err;
+            auto [ch1, ch2, ch3, ch4, ch5] = read_fn.read5();
+            if (ch1 >> 6 != 2) goto _err;
+            if (ch2 >> 6 != 2) goto _err;
+            if (ch3 >> 6 != 2) goto _err;
+            if (ch4 >> 6 != 2) goto _err;
+            if (ch5 >> 6 != 2) goto _err;
             return (ch0 << 30) + (ch1 << 24) + (ch2 << 18) + (ch3 << 12) + (ch4 << 6) + ch5 - 0x82082080;
         }
         throw std::runtime_error("The utf8 first char in sequence is incorrect");
         _err: throw std::runtime_error("The utf8 slave char in sequence is incorrect");
     }
 
+#define UTF8_BYTE_2 static_cast<char_type>(0x80 | (cp & 0x3F))
+#define UTF8_BYTE_3 static_cast<char_type>(0x80 | (cp >> 6 & 0x3F))
+#define UTF8_BYTE_4 static_cast<char_type>(0x80 | (cp >> 12 & 0x3F))
+#define UTF8_BYTE_5 static_cast<char_type>(0x80 | (cp >> 18 & 0x3F))
+#define UTF8_BYTE_6 static_cast<char_type>(0x80 | (cp >> 24 & 0x3F))
+
     template<typename WriteFn>
-    static void write(uint32_t const cp, WriteFn && write_fn)
+    FORCE_INLINE static void write(uint32_t const cp, WriteFn && write_fn)
     {
         if (cp < 0x80)          // 0xxx_xxxx
-            write_fn(static_cast<char_type>(cp));
+            write_fn.write1(static_cast<char_type>(cp));
         else if (cp < 0x800)    // 110x_xxxx 10xx_xxxx
         {
-            write_fn(static_cast<char_type>(0xC0 | cp >>  6));
-            goto _1;
+            write_fn.write2(static_cast<char_type>(0xC0 | cp >>  6),
+                            UTF8_BYTE_2);
         }
         else if (cp < 0x10000)  // 1110_xxxx 10xx_xxxx 10xx_xxxx
         {
-            write_fn(static_cast<char_type>(0xE0 | cp >> 12));
-            goto _2;
+            write_fn.write3(static_cast<char_type>(0xE0 | cp >> 12),
+                            UTF8_BYTE_3,
+                            UTF8_BYTE_2);
         }
         else if (cp < 0x200000) // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
         {
-            write_fn(static_cast<char_type>(0xF0 | cp >> 18));
-            goto _3;
+            write_fn.write4(static_cast<char_type>(0xF0 | cp >> 18),
+                            UTF8_BYTE_4,
+                            UTF8_BYTE_3,
+                            UTF8_BYTE_2);
         }
         else if (cp < 0x4000000) // 1111_10xx 10xx_xxxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
         {
-            write_fn(static_cast<char_type>(0xF8 | cp >> 24));
-            goto _4;
+            write_fn.write5(static_cast<char_type>(0xF8 | cp >> 24),
+                            UTF8_BYTE_5,
+                            UTF8_BYTE_4,
+                            UTF8_BYTE_3,
+                            UTF8_BYTE_2);
         }
         else if (cp < 0x80000000) // 1111_110x 10xx_xxxx 10xx_xxxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
         {
-            write_fn(static_cast<char_type>(0xFC | cp >> 30));
-            goto _5;
+            write_fn.write6(static_cast<char_type>(0xFC | cp >> 30),
+                            UTF8_BYTE_6,
+                            UTF8_BYTE_5,
+                            UTF8_BYTE_4,
+                            UTF8_BYTE_3,
+                            UTF8_BYTE_2);
         }
         else
             throw std::runtime_error("Tool large UTF8 code point");
         return;
-        _5: write_fn(static_cast<char_type>(0x80 | (cp >> 24 & 0x3F)));
-        _4: write_fn(static_cast<char_type>(0x80 | (cp >> 18 & 0x3F)));
-        _3: write_fn(static_cast<char_type>(0x80 | (cp >> 12 & 0x3F)));
-        _2: write_fn(static_cast<char_type>(0x80 | (cp >>  6 & 0x3F)));
-        _1: write_fn(static_cast<char_type>(0x80 | (cp       & 0x3F)));
     }
+
+#undef UTF8_BYTE_2
+#undef UTF8_BYTE_3
+#undef UTF8_BYTE_4
+#undef UTF8_BYTE_5
+#undef UTF8_BYTE_6
+
 };
 
 }}

--- a/include/ww898/utf_config.hpp
+++ b/include/ww898/utf_config.hpp
@@ -39,3 +39,11 @@ namespace ww898 {
 namespace utf {
 static uint32_t const max_unicode_code_point = 0x10FFFF;
 }}
+
+#if defined(_MSC_VER)
+    #pragma warning(error: 4714) // function marked as __forceinline not inlined
+    #define FORCE_INLINE __forceinline
+#else
+    #define FORCE_INLINE [[gnu::always_inline]]
+#endif
+

--- a/include/ww898/utf_iter.hpp
+++ b/include/ww898/utf_iter.hpp
@@ -1,0 +1,408 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2019 Mikhail Pilin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace ww898 {
+namespace utf {
+
+namespace detail {
+
+// wrapper around a random-access iterator that reads a few elements at a time, no bounds check
+template<typename It, typename TChar>
+struct ReadIterRnd
+{
+    using InternalIt = It;
+    ReadIterRnd(It init) :it(init) {}
+    It it;
+
+    It get() {
+        return it;
+    }
+    auto read1()
+    {
+        const TChar a = *it++;
+        return a;
+    }
+    auto read2()
+    {
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        it += 2;
+        return std::tuple(a, b);
+    }
+    auto read3()
+    {
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        const TChar c = *(it + 2);
+        it += 3;
+        return std::tuple(a, b, c);
+    }
+    auto read4()
+    {
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        const TChar c = *(it + 2);
+        const TChar d = *(it + 3);
+        it += 4;
+        return std::tuple(a, b, c, d);
+    }
+    auto read5()
+    {
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        const TChar c = *(it + 2);
+        const TChar d = *(it + 3);
+        const TChar e = *(it + 4);
+        it += 5;
+        return std::tuple(a, b, c, d, e);
+    }
+};
+
+// explicit specialization for const char* that passes the result as uint32_t to generate slightly more optimized code
+template<>
+struct ReadIterRnd<const char*, uint8_t>
+{
+    using InternalIt = const uint8_t*;
+    ReadIterRnd(const char* init) :it(reinterpret_cast<InternalIt>(init)) {}
+    // internal representation needs to be unsigned to avoid sign-extension issues
+    InternalIt it;
+
+    const char* get() {
+        return (const char*)it;
+    }
+    auto read1()
+    {
+        const uint32_t a = *it++;
+        return a;
+    }
+    auto read2()
+    {
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        it += 2;
+        return std::tuple(a, b);
+    }
+    auto read3()
+    {
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        const uint32_t c = *(it + 2);
+        it += 3;
+        return std::tuple(a, b, c);
+    }
+    auto read4()
+    {
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        const uint32_t c = *(it + 2);
+        const uint32_t d = *(it + 3);
+        it += 4;
+        return std::tuple(a, b, c, d);
+    }
+    auto read5()
+    {
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        const uint32_t c = *(it + 2);
+        const uint32_t d = *(it + 3);
+        const uint32_t e = *(it + 4);
+        it += 5;
+        return std::tuple(a, b, c, d, e);
+    }
+};
+
+// read iterator, random access, range checked with an end iterator
+template<typename It, typename TChar>
+struct ReadIterRndChecked
+{
+    using InternalIt = It;
+    ReadIterRndChecked(It init, It einit) :it(init), eit(einit) {}
+    It it, eit;
+
+    auto read1()
+    {
+        if (it == eit)
+            throw std::runtime_error("Not enough input");
+        const TChar a = *it++;
+        return a;
+    }
+    auto read2()
+    {
+        if (1 >= eit - it)
+            throw std::runtime_error("Not enough input");
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        it += 2;
+        return std::tuple(a, b);
+    }
+    auto read3()
+    {
+        if (2 >= eit - it)
+            throw std::runtime_error("Not enough input");
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        const TChar c = *(it + 2);
+        it += 3;
+        return std::tuple(a, b, c);
+    }
+    auto read4()
+    {
+        if (3 >= eit - it)
+            throw std::runtime_error("Not enough input");
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        const TChar c = *(it + 2);
+        const TChar d = *(it + 3);
+        it += 4;
+        return std::tuple(a, b, c, d);
+    }
+    auto read5()
+    {
+        if (4 >= eit - it)
+            throw std::runtime_error("Not enough input");
+        const TChar a = *it;
+        const TChar b = *(it + 1);
+        const TChar c = *(it + 2);
+        const TChar d = *(it + 3);
+        const TChar e = *(it + 4);
+        it += 5;
+        return std::tuple(a, b, c, d, e);
+    }
+};
+
+// specialization to const char* iterator that does the above uint32_t expansion and also does addtion (LEA opcode) in the pointer arithmatics instead of subtraction (SUB opcode)
+template<>
+struct ReadIterRndChecked<const char*, uint8_t>
+{
+    using InternalIt = const uint8_t*;
+    ReadIterRndChecked(const char* init, const char* einit) :it(reinterpret_cast<InternalIt>(init)), eit(reinterpret_cast<InternalIt>(einit)) {}
+    InternalIt it, eit;
+
+    auto read1()
+    {
+        if (it == eit)
+            throw std::runtime_error("Not enough input");
+        const uint32_t a = *it++;
+        return a;
+    }
+    auto read2()
+    {
+        if (it + 1 >= eit)
+            throw std::runtime_error("Not enough input");
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        it += 2;
+        return std::tuple(a, b);
+    }
+    auto read3()
+    {
+        if (it + 2 >= eit)
+            throw std::runtime_error("Not enough input");
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        const uint32_t c = *(it + 2);
+        it += 3;
+        return std::tuple(a, b, c);
+    }
+    auto read4()
+    {
+        if (it + 3 >= eit)
+            throw std::runtime_error("Not enough input");
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        const uint32_t c = *(it + 2);
+        const uint32_t d = *(it + 3);
+        it += 4;
+        return std::tuple(a, b, c, d);
+    }
+    auto read5()
+    {
+        if (it + 4 >= eit)
+            throw std::runtime_error("Not enough input");
+        const uint32_t a = *it;
+        const uint32_t b = *(it + 1);
+        const uint32_t c = *(it + 2);
+        const uint32_t d = *(it + 3);
+        const uint32_t e = *(it + 4);
+        it += 5;
+        return std::tuple(a, b, c, d, e);
+    }
+};
+
+// read iterator, with null termination check
+template<typename It, typename TChar>
+struct ReadIterZChecked
+{
+    using InternalIt = It;
+    ReadIterZChecked(It init) :it(init) {}
+    It it;
+
+    // legitimate null terminator is only read here
+    auto read1()
+    {
+        const TChar a = *it++;
+        return a;
+    }
+
+    auto read1_noz()
+    {
+        const TChar c = *it++;
+        if (c == 0)
+            throw std::runtime_error("Unexpected null termination");
+        return c;
+    }
+
+    // if we're reading more than 1 element, none of them should be 0
+    auto read2()
+    {
+        const TChar a = read1_noz();
+        const TChar b = read1_noz();
+        return std::tuple(a, b);
+    }
+    auto read3()
+    {
+        const TChar a = read1_noz();
+        const TChar b = read1_noz();
+        const TChar c = read1_noz();
+        return std::tuple(a, b, c);
+    }
+    auto read4()
+    {
+        const TChar a = read1_noz();
+        const TChar b = read1_noz();
+        const TChar c = read1_noz();
+        const TChar d = read1_noz();
+        return std::tuple(a, b, c, d);
+    }
+    auto read5()
+    {
+        const TChar a = read1_noz();
+        const TChar b = read1_noz();
+        const TChar c = read1_noz();
+        const TChar d = read1_noz();
+        const TChar e = read1_noz();
+        return std::tuple(a, b, c, d, e);
+    }
+};
+
+// read wrapper for non-random-access iterator
+template<typename It, typename TChar>
+struct ReadIterSeqChecked
+{
+    using InternalIt = It;
+    ReadIterSeqChecked(It init, It einit) :it(init), eit(einit) {}
+    It it, eit;
+
+    auto read1()
+    {
+        if (it == eit)
+            throw std::runtime_error("Not enough input");
+        const TChar a = *it++;
+        return a;
+    }
+
+    auto read2()
+    {
+        const TChar a = read1();
+        const TChar b = read1();
+        return std::tuple(a, b);
+    }
+    auto read3()
+    {
+        const TChar a = read1();
+        const TChar b = read1();
+        const TChar c = read1();
+        return std::tuple(a, b, c);
+    }
+    auto read4()
+    {
+        const TChar a = read1();
+        const TChar b = read1();
+        const TChar c = read1();
+        const TChar d = read1();
+        return std::tuple(a, b, c, d);
+    }
+    auto read5()
+    {
+        const TChar a = read1();
+        const TChar b = read1();
+        const TChar c = read1();
+        const TChar d = read1();
+        const TChar e = read1();
+        return std::tuple(a, b, c, d, e);
+    }
+};
+
+
+// write iterator wrapper
+template<typename Oit, typename TChar>
+struct WriteIter
+{
+    Oit oit;
+    void write1(const TChar ch)
+    {
+        *oit++ = ch;
+    }
+    void write2(const TChar ch1, const TChar ch2)
+    {
+        *oit++ = ch1;
+        *oit++ = ch2;
+    }
+    void write3(const TChar ch1, const TChar ch2, const TChar ch3)
+    {
+        *oit++ = ch1;
+        *oit++ = ch2;
+        *oit++ = ch3;
+    }
+    void write4(const TChar ch1, const TChar ch2, const TChar ch3, const TChar ch4)
+    {
+        *oit++ = ch1;
+        *oit++ = ch2;
+        *oit++ = ch3;
+        *oit++ = ch4;
+    }
+    void write5(const TChar ch1, const TChar ch2, const TChar ch3, const TChar ch4, const TChar ch5)
+    {
+        *oit++ = ch1;
+        *oit++ = ch2;
+        *oit++ = ch3;
+        *oit++ = ch4;
+        *oit++ = ch5;
+    }
+    void write6(const TChar ch1, const TChar ch2, const TChar ch3, const TChar ch4, const TChar ch5, const TChar ch6)
+    {
+        *oit++ = ch1;
+        *oit++ = ch2;
+        *oit++ = ch3;
+        *oit++ = ch4;
+        *oit++ = ch5;
+        *oit++ = ch6;
+    }
+};
+
+}}}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCE_FILES
 	../include/ww898/utf_config.hpp
 	../include/ww898/utf_selector.hpp
 	../include/ww898/utf_sizes.hpp
+	../include/ww898/utf_iter.hpp
 	../include/ww898/utf_converters.hpp
 	utf_converters_test.cpp)
 
@@ -37,13 +38,15 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	target_compile_options(utf-cpp-test PRIVATE
                 /W3
 		"$<$<CONFIG:Release>:/GL>"
-		"$<$<CONFIG:Release>:/Ox>"
+		"$<$<CONFIG:Release>:/O2>"
 		"$<$<CONFIG:Release>:/Ob2>"
 		"$<$<CONFIG:Release>:/Ot>"
 		"$<$<CONFIG:Release>:/Oi>"
 		"$<$<CONFIG:Release>:/Oy->")
 
-	if(MSVC_VERSION MATCHES "^19[1-9][0-9]$")
+	if(MSVC_VERSION MATCHES "^19[3-9][0-9]$")
+		target_compile_options(utf-cpp-test PRIVATE /std:c++20)
+	elseif(MSVC_VERSION MATCHES "^19[1-2][0-9]$")
 		target_compile_options(utf-cpp-test PRIVATE /std:c++17)
 	elseif(MSVC_VERSION STREQUAL 1900)
 		target_compile_options(utf-cpp-test PRIVATE /std:c++14)


### PR DESCRIPTION
I implemented a few optimizations that increase performance by about 200%

<table>
<tr><td>Before (original code)</td><td>After</td></tr>
<tr><td>

```
Running 498 test cases...
compiler: MSVC v19.34.31937
architecture: x64
__cpp_lib_string_view: 201803
sizeof wchar_t: 2
UTFW: UTF16
Resolution: 1497604738
UTF8  ==> UTF8 : 0.046760979s
UTF8  ==> UTF16: 0.120738046s
UTF8  ==> UTF32: 0.116526514s
UTF8  ==> UTFW : 0.125314060s
UTF16 ==> UTF8 : 0.149225085s
UTF16 ==> UTF16: 0.025468075s
UTF16 ==> UTF32: 0.044913877s
UTF16 ==> UTFW : 0.037495761s
UTF32 ==> UTF8 : 0.149762023s
UTF32 ==> UTF16: 0.080844693s
UTF32 ==> UTF32: 0.016662613s
UTF32 ==> UTFW : 0.083288181s
UTFW  ==> UTF8 : 0.148268501s
UTFW  ==> UTF16: 0.039871186s
UTFW  ==> UTF32: 0.046740020s
UTFW  ==> UTFW : 0.028833317s
codecvt_utf8_utf16<char16_t>:
UTF16 ==> UTF8 : 0.312078935s (+109.13%)
UTF8  ==> UTF16: 0.229479163s (+90.06%)
codecvt_utf8_utf16<wchar_t>:
UTFW  ==> UTF8 : 0.325835292s (+119.76%)
UTF8  ==> UTFW : 0.235868838s (+88.22%)

*** No errors detected
```

</td><td>

```
Running 532 test cases...
compiler: MSVC v19.34.31937
architecture: x64
__cpp_lib_string_view: 201803
sizeof wchar_t: 2
UTFW: UTF16
Resolution: 1497608346
UTF8  ==> UTF8 : 0.020368061s
UTF8  ==> UTF16: 0.054659417s
UTF8  ==> UTF32: 0.045423582s
UTF8  ==> UTFW : 0.052922389s
UTF16 ==> UTF8 : 0.051900870s
UTF16 ==> UTF16: 0.011311742s
UTF16 ==> UTF32: 0.031817055s
UTF16 ==> UTFW : 0.011952694s
UTF32 ==> UTF8 : 0.041485858s
UTF32 ==> UTF16: 0.032115685s
UTF32 ==> UTF32: 0.009692607s
UTF32 ==> UTFW : 0.033776585s
UTFW  ==> UTF8 : 0.047951779s
UTFW  ==> UTF16: 0.013337822s
UTFW  ==> UTF32: 0.031452300s
UTFW  ==> UTFW : 0.012163787s
codecvt_utf8_utf16<char16_t>:
UTF16 ==> UTF8 : 0.284035091s (+447.26%)
UTF8  ==> UTF16: 0.191992105s (+251.25%)
codecvt_utf8_utf16<wchar_t>:
UTFW  ==> UTF8 : 0.285054652s (+494.46%)
UTF8  ==> UTFW : 0.202671043s (+282.96%)

*** No errors detected
```

</td>
</tr>
</table>

To get to this result I implemented serveral changes:

- Changed `run_measure()` in the performance test from using `std::back_inserter()` to use a pointer to the start of the output buffer. Having `back_inserter()` as the output iterator pollutes the measurment by adding a part of `std::vector` into the test.
- Added force-inline attribute to all `read()` and `write()` methods. UTF-8 `read()` was too large to qualify for inlining.

One major change is in how `conv_strategy` references the input the output iterators.  
The original code captured the input iterator by reference in a lambda. This caused the code that was generated in `read()` to have to do 2 indirections:

```           
char_type const ch1 = read_fn(); if (ch1 >> 6 != 2) goto _err;
         mov         rcx,qword ptr [rcx]  
         mov         rax,qword ptr [rcx]  
         movzx       edx,byte ptr [rax]  
         inc         rax  
         mov         qword ptr [rcx],rax  
```
In  the new code this is changed to:
```            
char_type const ch1 = read_fn.read1(); 
         movzx       ecx,byte ptr [rax]  
         inc         rax  
         mov         qword ptr [r8],rax  
```

Fixing this was the motivating for replacing the lambdas with a set of iterator wrapper classes that takes the input iterator by value (`ReadIterRnd`). Having an iterator wrapper class allowed a few more optimizations to be subsequently added:

- Instead of reading input elements one by one, read them a few at a time. This is significant in the UTF-8 reader that can read 3-4 bytes at a time, and leads to better generated code.
- An explicit specialization for the `const char*` reader case was added where input bytes are converts to `uint32_t` before returning to `read()`. This allows better generated code since the optimizer can deal with full sized registers instead of bytes.
- `ReadIterRndChecked` is used for the last few code points that require bounds checking. the check is made per group of 2-5 elements instead of on every element (byte for UTF-8) read.
- UTF-8 `write()` was changed to do with less brancing (at the cost of duplicating code using macros)

A few missing test-cases were added

- Converting a strings that end in a partial code-point should throw an exception
- Usage of non-random-access iterators

Tested with Visual Studio 2022, toolkit v143.  
The code uses a few modern features like std::tuple and structured binding so it doesn't compile on older toolkits. If this support is a priority I can try to rework these parts.

Future work:
- It would be interesting to try to implement UTF-8 recovery and resync after detecting a bad sequence in the middle of a string, and do so without a performance impact to the normal case.

------
The goal of this PR was to try to get your attention to my recent job application to the Profiler Core team at JetBrains. I thought seeing code could be better than any cover letter I could write.  
If you're looking for someone who can read and understand code fast, enjoys tinkering with assembly code and working for 3 days to make the optimizer do a better job, please contact me - shooshx@gmail.com

